### PR TITLE
Added experimental approach to refinment for attribution of shared co…

### DIFF
--- a/src/01_github-wrangling/06_commits_nmrc_jbsc.sql
+++ b/src/01_github-wrangling/06_commits_nmrc_jbsc.sql
@@ -1,0 +1,84 @@
+create materialized view gh.commits_freq as (
+    with a as (
+        SELECT committed_date,
+            login,
+            additions,
+            deletions,
+            count(*)
+        FROM gh.commits_dd
+        group by committed_date,
+            login,
+            additions,
+            deletions
+    )
+    select *
+    from a
+    where count > 1
+    order by count desc,
+        committed_date,
+        login,
+        additions,
+        deletions
+);
+create materialized view gh.commits_freq_0 as (
+ SELECT a.slug,
+    a.committed_date,
+    a.login,
+    a.additions,
+    a.deletions
+   FROM gh.commits_dd a
+   JOIN gh.commits_freq b
+   ON a.committed_date = b.committed_date
+   AND a.login = b.login
+   AND a.additions = b.additions
+   AND a.deletions = b.deletions
+);
+create materialized view gh.commits_freq_1 as (
+    with a as (
+        SELECT slug,
+            max(committed_date),
+            min(committed_date)
+        FROM gh.commits_freq_0
+        group by slug
+    ),
+    b as (
+        select distinct on (slug) slug,
+            max - min as duration
+        from a
+        order by slug,
+            duration desc
+    )
+    select distinct a.*
+    from gh.commits_freq_0 a
+    join b
+    on a.slug = b.slug
+);
+create materialized view gh.commits_dd_nmrc_jbsc as (
+    with a as (
+        select *,
+            false to_keep
+        from gh.commits_dd
+        union all
+        select *,
+            true to_keep
+        from gh.commits_freq_1
+    ),
+    b as (
+        select distinct on (committed_date, login, additions, deletions) *
+        from a
+        order by committed_date,
+            login,
+            additions,
+            deletions,
+            to_keep desc
+    )
+    select distinct slug,
+        committed_date,
+        login,
+        additions,
+        deletions
+    from b
+    order by slug,
+        committed_date,
+        login
+);

--- a/src/01_github-wrangling/06_commits_nmrc_jbsc.sql
+++ b/src/01_github-wrangling/06_commits_nmrc_jbsc.sql
@@ -1,4 +1,5 @@
 create materialized view gh.commits_freq as (
+    -- Find how many times a commit show up
     with a as (
         SELECT committed_date,
             login,
@@ -10,7 +11,7 @@ create materialized view gh.commits_freq as (
             login,
             additions,
             deletions
-    )
+    ) -- Find all commits which appear in multiple repos
     select *
     from a
     where count > 1
@@ -21,19 +22,20 @@ create materialized view gh.commits_freq as (
         deletions
 );
 create materialized view gh.commits_freq_0 as (
- SELECT a.slug,
-    a.committed_date,
-    a.login,
-    a.additions,
-    a.deletions
-   FROM gh.commits_dd a
-   JOIN gh.commits_freq b
-   ON a.committed_date = b.committed_date
-   AND a.login = b.login
-   AND a.additions = b.additions
-   AND a.deletions = b.deletions
+    -- Find the slugs of each commit that appears in multiple repos
+    SELECT a.slug,
+        a.committed_date,
+        a.login,
+        a.additions,
+        a.deletions
+    FROM gh.commits_dd a
+        JOIN gh.commits_freq b ON a.committed_date = b.committed_date
+        AND a.login = b.login
+        AND a.additions = b.additions
+        AND a.deletions = b.deletions
 );
 create materialized view gh.commits_freq_1 as (
+    -- Compute the earliest and most recent "shared" commit for each repo
     with a as (
         SELECT slug,
             max(committed_date),
@@ -41,6 +43,9 @@ create materialized view gh.commits_freq_1 as (
         FROM gh.commits_freq_0
         group by slug
     ),
+    -- Compute the duration from earliest to most recent "shared" commit
+    -- in each repo and keep only the slug of the repo with the longest
+    -- chain
     b as (
         select distinct on (slug) slug,
             max - min as duration
@@ -48,12 +53,15 @@ create materialized view gh.commits_freq_1 as (
         order by slug,
             duration desc
     )
+    -- For each commit, assign the repo in which it shows up having the
+    -- longest chain
     select distinct a.*
     from gh.commits_freq_0 a
-    join b
-    on a.slug = b.slug
+        join b on a.slug = b.slug
 );
 create materialized view gh.commits_dd_nmrc_jbsc as (
+    -- Have original records and the "refined" records
+    -- give preference to refined ones over the orginal ones
     with a as (
         select *,
             false to_keep
@@ -63,6 +71,7 @@ create materialized view gh.commits_dd_nmrc_jbsc as (
             true to_keep
         from gh.commits_freq_1
     ),
+    -- Remove original records for which there is a refined one
     b as (
         select distinct on (committed_date, login, additions, deletions) *
         from a
@@ -72,6 +81,7 @@ create materialized view gh.commits_dd_nmrc_jbsc as (
             deletions,
             to_keep desc
     )
+    -- Final clean up which has every commit just ones based on the refinement
     select distinct slug,
         committed_date,
         login,


### PR DESCRIPTION
Hi Brandon,

You should have access to the `gh.commits_dd_nmrc_jbsc`. Let me know if that works for updating the estimates based on your code.

Cheers!

Summary
--

Multiple repositories may have the same commit history for multiple reasons. For example, templates will have a common history of commits in each repository until when diverging activity occurs. The commits can potentially be back-ported so it is not assumed that the chain of shared commit history stops until the x divergence. For the cost estimates, we wish to attribute the common activity to the "original" project. There is no clear way of doing this but the heuristic employed here is the following:

- Identify all commits that show up in multiple repositories (in this version we are using `committed_data`, `login`, `additions`, and `deletions` but in the newer dataset it would be based on the SHA1 and maybe additional variables. For example,
```
{
  nodes(ids: ["MDEwOlJlcG9zaXRvcnkxMTE2MDQ4MTM=", "MDEwOlJlcG9zaXRvcnkyMTE3ODU2NjY="]) {
    ... on Repository {
      nameWithOwner
      defaultBranchRef {
        target {
          ... on Commit {
            history(since: "2019-09-25T00:00:00Z", until: "2019-09-26T00:00:00Z", first: 3) {
              edges {
                node {
                  id
                  oid
                  committedDate
                  additions
                  deletions
                  author {
                    user {
                      login
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```
yields
```
{
  "data": {
    "nodes": [
      {
        "nameWithOwner": "Nosferican/JBSC",
        "defaultBranchRef": {
          "target": {
            "history": {
              "edges": [
                {
                  "node": {
                    "id": "MDY6Q29tbWl0MjExNzg1NjY2OmYyODc2NGE3NDIwMGQ5ZDQwMzhhOWY4ZjQ3MzNmNjBjNGI0NTE1Mjg=",
                    "oid": "f28764a74200d9d4038a9f8f4733f60c4b451528",
                    "committedDate": "2019-09-25T10:15:42Z",
                    "additions": 1,
                    "deletions": 1,
                    "author": {
                      "user": {
                        "login": "gcushen"
                      }
                    }
                  }
                }
              ]
            }
          }
        }
      },
      {
        "nameWithOwner": "wowchemy/starter-academic",
        "defaultBranchRef": {
          "target": {
            "history": {
              "edges": [
                {
                  "node": {
                    "id": "MDY6Q29tbWl0MTExNjA0ODEzOmYyODc2NGE3NDIwMGQ5ZDQwMzhhOWY4ZjQ3MzNmNjBjNGI0NTE1Mjg=",
                    "oid": "f28764a74200d9d4038a9f8f4733f60c4b451528",
                    "committedDate": "2019-09-25T10:15:42Z",
                    "additions": 1,
                    "deletions": 1,
                    "author": {
                      "user": {
                        "login": "gcushen"
                      }
                    }
                  }
                }
              ]
            }
          }
        }
      }
    ]
  }
}
```
- For each repository referenced in the shared commits collection, compute the extent of the chain based on the committed date of the earliest and most recent commit.
- Attribute the commits to the one of the repository with the longest duration (a future refinement may include break ties based favoring the oldest on GitHub).